### PR TITLE
reduced memory footprint of marching_cubes

### DIFF
--- a/mcubes/src/marchingcubes.h
+++ b/mcubes/src/marchingcubes.h
@@ -36,7 +36,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
     coord_type dy = (upper[1] - lower[1])/static_cast<coord_type>(numy);
     coord_type dz = (upper[2] - lower[2])/static_cast<coord_type>(numz);
     
-    size_t* shared_indices = new size_t[numx*numy*numz*3];
+    size_t* shared_indices = new size_t[2*numy*numz*3];
     const int z3 = numz*3;
     const int yz3 = numy*z3;
     
@@ -44,6 +44,9 @@ void marching_cubes(const vector3& lower, const vector3& upper,
     {
         coord_type x = lower[0] + dx*i;
         coord_type x_dx = lower[0] + dx*(i+1);
+        const int i_mod_2 = i % 2;
+        const int i_mod_2_inv = (i_mod_2 ? 0 : 1); 
+
         for(int j=0; j<numy; ++j)
         {
             coord_type y = lower[1] + dy*j;
@@ -71,19 +74,19 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                 if(edges & 0x040)
                 {
                     indices[6] = vertices.size() / 3;
-                    shared_indices[i*yz3 + j*z3 + k*3 + 0] = indices[6];
+                    shared_indices[i_mod_2*yz3 + j*z3 + k*3 + 0] = indices[6];
                     mc_add_vertex(x_dx, y_dy, z_dz, x, 0, v[6], v[7], isovalue, &vertices);
                 }
                 if(edges & 0x020)
                 {
                     indices[5] = vertices.size() / 3;
-                    shared_indices[i*yz3 + j*z3 + k*3 + 1] = indices[5];
+                    shared_indices[i_mod_2*yz3 + j*z3 + k*3 + 1] = indices[5];
                     mc_add_vertex(x_dx, y, z_dz, y_dy, 1, v[5], v[6], isovalue, &vertices);
                 }
                 if(edges & 0x400)
                 {
                     indices[10] = vertices.size() / 3;
-                    shared_indices[i*yz3 + j*z3 + k*3 + 2] = indices[10];                    
+                    shared_indices[i_mod_2*yz3 + j*z3 + k*3 + 2] = indices[10];                    
                     mc_add_vertex(x_dx, y+dx, z, z_dz, 2, v[2], v[6], isovalue, &vertices);
                 }
                 
@@ -95,7 +98,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                       mc_add_vertex(x, y, z, x_dx, 0, v[0], v[1], isovalue, &vertices);
                     }
                     else
-                        indices[0] = shared_indices[i*yz3 + (j-1)*z3 + (k-1)*3 + 0];
+                        indices[0] = shared_indices[i_mod_2*yz3 + (j-1)*z3 + (k-1)*3 + 0];
                 }
                 if(edges & 0x002)
                 {
@@ -105,7 +108,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x_dx, y, z, y_dy, 1, v[1], v[2], isovalue, &vertices);
                     }
                     else
-                        indices[1] = shared_indices[i*yz3 + j*z3 + (k-1)*3 + 1];
+                        indices[1] = shared_indices[i_mod_2*yz3 + j*z3 + (k-1)*3 + 1];
                 }
                 if(edges & 0x004)
                 {
@@ -115,7 +118,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x_dx, y_dy, z, x, 0, v[2], v[3], isovalue, &vertices);
                     }
                     else
-                        indices[2] = shared_indices[i*yz3 + j*z3 + (k-1)*3 + 0];
+                        indices[2] = shared_indices[i_mod_2*yz3 + j*z3 + (k-1)*3 + 0];
                 }
                 if(edges & 0x008)
                 {
@@ -125,7 +128,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x, y_dy, z, y, 1, v[3], v[0], isovalue, &vertices);
                     }
                     else
-                        indices[3] = shared_indices[(i-1)*yz3 + j*z3 + (k-1)*3 + 1];
+                        indices[3] = shared_indices[i_mod_2_inv*yz3 + j*z3 + (k-1)*3 + 1];
                 }
                 if(edges & 0x010)
                 {
@@ -135,7 +138,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x, y, z_dz, x_dx, 0, v[4], v[5], isovalue, &vertices);
                     }
                     else
-                        indices[4] = shared_indices[i*yz3 + (j-1)*z3 + k*3 + 0];
+                        indices[4] = shared_indices[i_mod_2*yz3 + (j-1)*z3 + k*3 + 0];
                 }
                 if(edges & 0x080)
                 {
@@ -145,7 +148,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x, y_dy, z_dz, y, 1, v[7], v[4], isovalue, &vertices);
                     }
                     else
-                        indices[7] = shared_indices[(i-1)*yz3 + j*z3 + k*3 + 1];
+                        indices[7] = shared_indices[i_mod_2_inv*yz3 + j*z3 + k*3 + 1];
                 }
                 if(edges & 0x100)
                 {
@@ -155,7 +158,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x, y, z, z_dz, 2, v[0], v[4], isovalue, &vertices);
                     }
                     else
-                        indices[8] = shared_indices[(i-1)*yz3 + (j-1)*z3 + k*3 + 2];
+                        indices[8] = shared_indices[i_mod_2_inv*yz3 + (j-1)*z3 + k*3 + 2];
                 }
                 if(edges & 0x200)
                 {
@@ -165,7 +168,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x_dx, y, z, z_dz, 2, v[1], v[5], isovalue, &vertices);
                     }
                     else
-                        indices[9] = shared_indices[i*yz3 + (j-1)*z3 + k*3 + 2];
+                        indices[9] = shared_indices[i_mod_2*yz3 + (j-1)*z3 + k*3 + 2];
                 }
                 if(edges & 0x800)
                 {
@@ -175,7 +178,7 @@ void marching_cubes(const vector3& lower, const vector3& upper,
                         mc_add_vertex(x, y_dy, z, z_dz, 2, v[3], v[7], isovalue, &vertices);
                     }
                     else
-                        indices[11] = shared_indices[(i-1)*yz3 + j*z3 + k*3 + 2];
+                        indices[11] = shared_indices[i_mod_2_inv*yz3 + j*z3 + k*3 + 2];
                 }
                 
                 int tri;


### PR DESCRIPTION
`memory size_t *shared_indices` was the memory limiting var in
marching_cubes and took 24byte per voxel while rendering the mesh.
Since the var is only needed for i and (i - 1) while processing in x
dimension, the x dimension is removable, see usage of i_mod_2 and
i_mod_2_inv