### PR TITLE
OFF Exporter

### DIFF
--- a/mcubes/__init__.py
+++ b/mcubes/__init__.py
@@ -1,3 +1,3 @@
 
 from ._mcubes import marching_cubes, marching_cubes_func
-from .exporter import export_mesh, export_obj
+from .exporter import export_mesh, export_obj, export_off

--- a/mcubes/exporter.py
+++ b/mcubes/exporter.py
@@ -15,20 +15,22 @@ def export_obj(vertices, triangles, filename):
         for f in triangles:
             fh.write("f {} {} {}\n".format(*(f + 1)))
 
+
 def export_off(vertices, triangles, filename):
     """
     Exports a mesh in the (.off) format.
     """
     
     with open(filename, 'w') as fh:
-	fh.write('OFF\n')
-	fh.write('{} {} 0\n'.format(len(vertices), len(faces))
-	
+        fh.write('OFF\n')
+        fh.write('{} {} 0\n'.format(len(vertices), len(triangles)))
+
         for v in vertices:
             fh.write("{} {} {}\n".format(*v))
             
         for f in triangles:
-            fh.write("3 {} {} {}\n".format(*(f)))
+            fh.write("3 {} {} {}\n".format(*f))
+
 
 def export_mesh(vertices, triangles, filename, mesh_name="mcubes_mesh"):
     """

--- a/mcubes/exporter.py
+++ b/mcubes/exporter.py
@@ -15,6 +15,21 @@ def export_obj(vertices, triangles, filename):
         for f in triangles:
             fh.write("f {} {} {}\n".format(*(f + 1)))
 
+def export_off(vertices, triangles, filename):
+    """
+    Exports a mesh in the (.off) format.
+    """
+    
+    with open(filename, 'w') as fh:
+	fh.write('OFF\n')
+	fh.write('{} {} 0\n'.format(len(vertices), len(faces))
+	
+        for v in vertices:
+            fh.write("{} {} {}\n".format(*v))
+            
+        for f in triangles:
+            fh.write("3 {} {} {}\n".format(*(f)))
+
 def export_mesh(vertices, triangles, filename, mesh_name="mcubes_mesh"):
     """
     Exports a mesh in the COLLADA (.dae) format.


### PR DESCRIPTION
Functionality to export a mesh as `.off` file; see e.g. [here](http://segeval.cs.princeton.edu/public/off_format.html) for a description of the format. Roughly, the format looks as follows:

    OFF
    n_vertices n_faces n_edges
    v1_x v1_y v1_z
    v2_x v2_y v2_z
    ...
    f1_n_vertices f1_v1 f1_v2 f1_v3 ... v1_vn
    f2_n_vertices f2_v1 f1_v2 f2_v3 ... v2_vn
    ...

where `n_edges` is `0` when using `export_off` and only triangular faces are used, i.e. `fi_n_vertices` is always `3`.

Usage is similar to exporting meshes as `.obj` or `.dae`:

    f = lambda x, y, z: x**2 + y**2 + z**2
    vertices, triangles = mcubes.marching_cubes_func((-10,-10,-10), (10,10,10), 100, 100, 100, f, 16)
    mcubes.export_off(vertices, triangles, "sphere.off")