### PR TITLE
Speed improvements

### DIFF
--- a/mcubes/src/marchingcubes.cpp
+++ b/mcubes/src/marchingcubes.cpp
@@ -299,34 +299,20 @@ double mc_isovalue_interpolation(double isovalue, double f1, double f2,
 size_t mc_add_vertex(double x1, double y1, double z1, double c2,
     int axis, double f1, double f2, double isovalue, std::vector<double>* vertices)
 {
-    size_t vertex_index = vertices->size() / 3;
-    if(axis == 0)
-    {
-        double x = mc_isovalue_interpolation(isovalue, f1, f2, x1, c2);
-        vertices->push_back(x);
-        vertices->push_back(y1);
-        vertices->push_back(z1);
-        return vertex_index;
-    }
-    if(axis == 1)
-    {
-        double y = mc_isovalue_interpolation(isovalue, f1, f2, y1, c2);
-        vertices->push_back(x1);
-        vertices->push_back(y);
-        vertices->push_back(z1);
-        return vertex_index;
-    }
-    if(axis == 2)
-    {
-        double z = mc_isovalue_interpolation(isovalue, f1, f2, z1, c2);
-        vertices->push_back(x1);
-        vertices->push_back(y1);
-        vertices->push_back(z);
-        return vertex_index;
-    }
-
-    // This should not happen.
-    return -1;
+    double calculated_value = mc_isovalue_interpolation(isovalue, f1, f2,
+        // Use maths instead of branches for quicker code
+        // True -> 1,  False -> 0
+          (x1 * (axis == 0))
+        + (y1 * (axis == 1))
+        + (z1 * (axis == 2)),
+    c2);
+    auto to_return = vertices->size()/3;
+    // Write in correct order with maths as well
+    vertices->push_back((calculated_value * (axis == 0)) + (x1 * (axis != 0)));
+    vertices->push_back((calculated_value * (axis == 1)) + (y1 * (axis != 1)));
+    vertices->push_back((calculated_value * (axis == 2)) + (z1 * (axis != 2))); 
+        
+    return to_return;
 }
 
 }


### PR DESCRIPTION

## Change set 1:
I had intended to make the function `mc::mc_add_vertex` branchless to improve performance but it was not more performant on quickbench. I then added "-ffast-math" and saw the performance decrease even more so there may be a flaw in my benchmark.

For documentation the code was:
``` C++
double calculated_value = mc_isovalue_interpolation(isovalue, f1, f2,
        // Use maths instead of branches for quicker code
        // True -> 1,  False -> 0
          (x1 * (axis == 0))
        + (y1 * (axis == 1))
        + (z1 * (axis == 2)),
    c2);
    auto to_return = vertices->size()/3;
    // Write in correct order with maths as well
    vertices->push_back((calculated_value * (axis == 0)) + (x1 * (axis != 0)));
    vertices->push_back((calculated_value * (axis == 1)) + (y1 * (axis != 1)));
    vertices->push_back((calculated_value * (axis == 2)) + (z1 * (axis != 2))); 
```
And was later changed to use ternary operators instead of floating point maths.

## Change set 2:
These changes relate to reserving the size of vectors before adding to them. 
By default vectors have a small capacity, the standard does not specify but (cppreference)[https://en.cppreference.com/w/cpp/container/vector/capacity] suggests they start at 0. When an item would be added past the end of the buffer the internal buffer goes through a reallocation. Normally this reallocation adds half the size of the buffer again, (growing by 1.5x). 

Reserving an initial estimate with `.reserve()` will heavily reduce the amount of allocations and increase the speed of the program. Overusing reserve (say reserving 3 in `mc_add_vertex`) can increase the amount of allocations, worsening performance.

Much better estimates may further increase performance.